### PR TITLE
wakuv2-test: rln-relay tree path for persistence

### DIFF
--- a/ansible/group_vars/wakuv2-test.yml
+++ b/ansible/group_vars/wakuv2-test.yml
@@ -54,6 +54,7 @@ nim_waku_rln_relay_content_topic: '/toy-chat/3/mingde/proto'
 nim_waku_rln_relay_dynamic: true
 nim_waku_rln_relay_eth_contract_address: '0x9C09146844C1326c2dBC41c451766C7138F88155'
 nim_waku_rln_relay_eth_client_address: 'ws://linux-01.ih-eu-mda1.nimbus.sepolia.wg:9557'
+nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 
 # Consul Service
 nim_waku_consul_success_before_passing: 5

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -27,7 +27,7 @@
 
 - name: nim-waku
   src: git@github.com:status-im/infra-role-nim-waku.git
-  version: eed1a10ccea90c3b33af845ba54334530467a625
+  version: 8044c33ffb92b3ee73cba677a090330ff638b70c
   scm: git
 
 - name: waku-peers


### PR DESCRIPTION
To align with https://github.com/waku-org/nwaku/pull/1805
